### PR TITLE
feat: add filter for capability to use custom js

### DIFF
--- a/additional-javascript.php
+++ b/additional-javascript.php
@@ -95,7 +95,7 @@ function register_additional_javascript( $wp_customize ) {
 	require_once dirname( __FILE__ ) . '/class-custom-javascript-control.php';
 	$custom_javascript_setting = new Soderlind_Customize_Custom_JavaScript_Setting(
 		$wp_customize, sprintf( 'custom_javascript[%s]', get_stylesheet() ), array(
-			'capability' => 'unfiltered_html',
+			'capability' => apply_filters( 'soderlind_custom_javascript_capability', 'unfiltered_html' ),
 			'default'    => '',
 		)
 	);


### PR DESCRIPTION
I wanted to change the required capability to use the custom js setting and found the only way was to remove the default hook on `customize_register` & run a slightly edited version of `register_additional_javascript()` in its place.

This PR adds a filter on the capability so it can be changed without replacing any plugin actions or methods. If you have a better idea I'm open to it, and if you're not interested I understand. Thanks again for this plugin!