### PR TITLE
Bump version to 1.1.4 in additional-javascript.php, package.json, pac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ The JavaScript is added at the end of the `<head>` section of your site with a p
 
 ## Changelog
 
+### 1.1.4
+* Enhanced class loading for the GitHub plugin updater.
+
 ### 1.1.3
 * Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
 

--- a/additional-javascript.php
+++ b/additional-javascript.php
@@ -12,7 +12,7 @@
  * Plugin URI:  https://github.com/soderlind/additional-javascript
  * GitHub Plugin URI: https://github.com/soderlind/additional-javascript
  * Description: Add additional JavaScript using the WordPress Customizer.
- * Version:     1.1.3
+ * Version:     1.1.4
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: additional-javascript
@@ -25,13 +25,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die();
 }
 
-define( 'ADDITIONAL_JAVASCRIPT_VERSION', '1.1.1' );
+define( 'ADDITIONAL_JAVASCRIPT_VERSION', '1.1.4' );
 define( 'ADDITIONAL_JAVASCRIPT_FILE', __FILE__ );
 define( 'ADDITIONAL_JAVASCRIPT_PATH', plugin_dir_path( ADDITIONAL_JAVASCRIPT_FILE ) );
 
 require_once ADDITIONAL_JAVASCRIPT_PATH . 'vendor/autoload.php';
 // Include the generic updater class
-require_once dirname( __FILE__ ) . '/class-github-plugin-updater.php';
+if ( ! class_exists( 'Soderlind\WordPress\GitHub_Plugin_Updater' ) ) {
+	require_once ADDITIONAL_JAVASCRIPT_PATH . 'class-github-plugin-updater.php';
+}
 // Initialize the updater with configuration.
 $additional_javascript_updater = \Soderlind\WordPress\GitHub_Plugin_Updater::create_with_assets(
 	'https://github.com/soderlind/additional-javascript',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "additional-javascript",
-	"version": "1.1.2",
+	"version": "1.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "additional-javascript",
-			"version": "1.1.2",
+			"version": "1.1.4",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "additional-javascript",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Add additional JavaScript using the WordPress Customizer.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: javascript, customizer, code, custom code, js
 Donate link: https://paypal.me/PerSoderlind
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 1.1.3
+Stable tag: 1.1.4
 Requires PHP: 8.2
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -61,6 +61,9 @@ No, the plugin is designed to be lightweight and only loads the necessary script
 The JavaScript is added at the end of the `<head>` section of your site with a priority of 110.
 
 == Changelog ==
+
+= 1.1.4 =
+* Enhanced class loading for the GitHub plugin updater.
 
 = 1.1.3 =
 * Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/additional-javascript',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'f75e4faf5bf987362eca6385bb4c10d6dd9dbf9b',
+        'reference' => '22f23630ecfe19338e339f4c91e96d87e550ae88',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/additional-javascript' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'f75e4faf5bf987362eca6385bb4c10d6dd9dbf9b',
+            'reference' => '22f23630ecfe19338e339f4c91e96d87e550ae88',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
This pull request updates the plugin to version 1.1.4 and introduces an enhancement to the class loading mechanism for the GitHub plugin updater. Below are the key changes:

### Version Update:
* Updated the plugin version from `1.1.3` to `1.1.4` in `additional-javascript.php`, `package.json`, and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-bcc74d5e844144e7348fcee57dbe466007c963afd1e192c0dd3ab520ba06241cL15-R15) [[2]](diffhunk://#diff-bcc74d5e844144e7348fcee57dbe466007c963afd1e192c0dd3ab520ba06241cL28-R36) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)

### Enhancements:
* Improved the class loading for the GitHub plugin updater by adding a conditional check to ensure the `Soderlind\WordPress\GitHub_Plugin_Updater` class is only loaded if it is not already defined.

### Documentation Updates:
* Added a changelog entry for version 1.1.4 in both `README.md` and `readme.txt`, highlighting the enhancement to the GitHub plugin updater. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R73) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R67)