### PR TITLE
 Fix deprecated PHP string interpolation syntax for PHP 8.2+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.1.5] - 2025-07-16
+
+### Fixed
+- Fixed deprecated PHP string interpolation syntax for PHP 8.2+ compatibility
+
+## [1.1.4] - 2024-XX-XX
+
+### Changed
+- Enhanced class loading for the GitHub plugin updater
+
+## [1.1.3] - 2024-XX-XX
+
+### Changed
+- Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
+
+## [1.1.2] - 2024-XX-XX
+
+### Changed
+- Minor code improvements
+
+## [1.1.1] - 2024-XX-XX
+
+### Added
+- Plugin updater
+
+## [1.1.0] - 2024-XX-XX
+
+### Changed
+- Updated compatibility with WordPress 6.5
+- Code improvements and optimization
+- Enhanced security measures
+
+## [1.0.0] - 2024-XX-XX
+
+### Added
+- Initial release

--- a/additional-javascript.php
+++ b/additional-javascript.php
@@ -12,7 +12,7 @@
  * Plugin URI:  https://github.com/soderlind/additional-javascript
  * GitHub Plugin URI: https://github.com/soderlind/additional-javascript
  * Description: Add additional JavaScript using the WordPress Customizer.
- * Version:     1.1.4
+ * Version:     1.1.5
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: additional-javascript
@@ -374,10 +374,10 @@ function customize_preview_additional_javascript() {
 function on_customize_controls_enqueue_scripts() {
 	$suffix = is_rtl() ? '-rtl' : '';
 	$handle = 'additional-javascript-controls' . $suffix;
-	$src    = plugins_url( "/css/customize-controls-custom-javascript${suffix}.css", __FILE__ );
+	$src    = plugins_url( "/css/customize-controls-custom-javascript{$suffix}.css", __FILE__ );
 	$deps   = [ 'customize-controls' ];
 
-	if ( file_exists( plugin_dir_path( __FILE__ ) . "css/customize-controls-custom-javascript${suffix}.css" ) ) {
+	if ( file_exists( plugin_dir_path( __FILE__ ) . "css/customize-controls-custom-javascript{$suffix}.css" ) ) {
 		wp_enqueue_style( $handle, $src, $deps, ADDITIONAL_JAVASCRIPT_VERSION );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "additional-javascript",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Add additional JavaScript using the WordPress Customizer.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: javascript, customizer, code, custom code, js
 Donate link: https://paypal.me/PerSoderlind
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 1.1.4
+Stable tag: 1.1.5
 Requires PHP: 8.2
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -61,6 +61,9 @@ No, the plugin is designed to be lightweight and only loads the necessary script
 The JavaScript is added at the end of the `<head>` section of your site with a priority of 110.
 
 == Changelog ==
+
+= 1.1.5 =
+* Fixed deprecated PHP string interpolation syntax for PHP 8.2+ compatibility
 
 = 1.1.4 =
 * Enhanced class loading for the GitHub plugin updater.


### PR DESCRIPTION
This pull request updates the plugin to version 1.1.5, addressing PHP 8.2+ compatibility issues and updating relevant metadata. The most significant changes include fixing deprecated PHP string interpolation syntax, updating the version number across files, and adding detailed changelog entries.

### Fixes for PHP 8.2+ Compatibility:
* Updated the PHP string interpolation syntax in `additional-javascript.php` to use curly braces instead of the deprecated format.

### Metadata Updates:
* Updated the plugin version to `1.1.5` in `additional-javascript.php`, `package.json`, and `readme.txt`. [[1]](diffhunk://#diff-bcc74d5e844144e7348fcee57dbe466007c963afd1e192c0dd3ab520ba06241cL15-R15) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Added a new entry for version `1.1.5` in the changelog within `readme.txt` and the newly created `CHANGELOG.md`. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R67) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R40)