### PR TITLE
Inline the custom JavaScript using wp_print_inline_script_tag()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.6] - 2025-08-11
+
+### Fixed
+- Inline the custom javascript using `	()`
+- Ensure the script is printed in the footer
+
 ## [1.1.5] - 2025-07-16
 
 ### Fixed

--- a/additional-javascript.php
+++ b/additional-javascript.php
@@ -12,7 +12,7 @@
  * Plugin URI:  https://github.com/soderlind/additional-javascript
  * GitHub Plugin URI: https://github.com/soderlind/additional-javascript
  * Description: Add additional JavaScript using the WordPress Customizer.
- * Version:     1.1.5
+ * Version:     1.1.6
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: additional-javascript
@@ -44,7 +44,7 @@ $additional_javascript_updater = \Soderlind\WordPress\GitHub_Plugin_Updater::cre
 );
 
 add_action( 'init', __NAMESPACE__ . '\register_post_type_javascript', 0 );
-add_action( 'wp_head', __NAMESPACE__ . '\soderlind_custom_javascript_cb', 110 );
+add_action( 'wp_footer', __NAMESPACE__ . '\soderlind_custom_javascript_cb', 110 );
 add_action( 'customize_register', __NAMESPACE__ . '\register_additional_javascript' );
 add_action( 'customize_preview_init', __NAMESPACE__ . '\customize_preview_additional_javascript' );
 add_action( 'customize_controls_enqueue_scripts', __NAMESPACE__ . '\on_customize_controls_enqueue_scripts' );
@@ -120,11 +120,7 @@ function register_post_type_javascript() {
 function soderlind_custom_javascript_cb() {
 	$javascript = soderlind_get_custom_javascript();
 	if ( $javascript || is_customize_preview() ) {
-		?>
-		<script id="soderlind-custom-javascript">
-			<?php echo $javascript; ?>
-		</script>
-		<?php
+		wp_print_inline_script_tag( $javascript, [ 'id' => 'soderlind-custom-javascript' ] );
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "additional-javascript",
-	"version": "1.1.4",
+	"version": "1.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "additional-javascript",
-			"version": "1.1.4",
+			"version": "1.1.6",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "additional-javascript",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "Add additional JavaScript using the WordPress Customizer.",
 	"keywords": [
 		"wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: javascript, customizer, code, custom code, js
 Donate link: https://paypal.me/PerSoderlind
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 Requires PHP: 8.2
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -61,6 +61,10 @@ No, the plugin is designed to be lightweight and only loads the necessary script
 The JavaScript is added at the end of the `<head>` section of your site with a priority of 110.
 
 == Changelog ==
+
+= 1.1.6 =
+* Inline the custom javascript using `wp_print_inline_script_tag()`
+* Ensure the script is printed in the footer
 
 = 1.1.5 =
 * Fixed deprecated PHP string interpolation syntax for PHP 8.2+ compatibility


### PR DESCRIPTION
This pull request updates the plugin to version 1.1.6 and addresses how custom JavaScript is added to WordPress sites. The main improvements are switching to the recommended WordPress function for inlining JavaScript and moving the script output from the page header to the footer for better performance and compatibility.

**JavaScript Output Improvements:**

* Changed the method for inlining custom JavaScript to use `wp_print_inline_script_tag()`, which is the WordPress-recommended approach for adding inline scripts.
* Moved the output of the custom JavaScript from the `<head>` (using `wp_head`) to the footer (using `wp_footer`), ensuring scripts are loaded at the optimal time.

**Version and Documentation Updates:**

* Bumped the plugin version to 1.1.6 in `additional-javascript.php`, `package.json`, and updated the stable tag in `readme.txt`. [[1]](diffhunk://#diff-bcc74d5e844144e7348fcee57dbe466007c963afd1e192c0dd3ab520ba06241cL15-R15) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Updated the changelog in both `CHANGELOG.md` and `readme.txt` to document these changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R68)